### PR TITLE
Implement timeslot creation and booking validation

### DIFF
--- a/src/main/java/com/kata/delivery/application/exception/TimeslotUnavailableException.java
+++ b/src/main/java/com/kata/delivery/application/exception/TimeslotUnavailableException.java
@@ -1,0 +1,7 @@
+package com.kata.delivery.application.exception;
+
+public class TimeslotUnavailableException extends RuntimeException {
+    public TimeslotUnavailableException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/kata/delivery/domain/TimeslotRepository.java
+++ b/src/main/java/com/kata/delivery/domain/TimeslotRepository.java
@@ -2,10 +2,15 @@ package com.kata.delivery.domain;
 
 import java.time.LocalDate;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 
 /**
  * Repository exposing domain {@link Timeslot} value objects.
  */
 public interface TimeslotRepository {
     Flux<Timeslot> findByModeAndDate(DeliveryMode mode, LocalDate date);
+
+    Mono<Timeslot> findById(Long id);
+
+    Mono<Timeslot> save(Timeslot timeslot);
 }

--- a/src/main/java/com/kata/delivery/exposition/DeliveryController.java
+++ b/src/main/java/com/kata/delivery/exposition/DeliveryController.java
@@ -27,6 +27,11 @@ public class DeliveryController {
         return service.availableTimeslots(mode, date);
     }
 
+    @PostMapping("/timeslots")
+    public Mono<TimeslotDto> addTimeslot(@RequestBody TimeslotDto timeslot) {
+        return service.addTimeslot(timeslot);
+    }
+
     @PostMapping("/deliveries")
     public Mono<DeliveryDto> book(@RequestBody DeliveryRequest request) {
         return service.book(request);

--- a/src/main/java/com/kata/delivery/exposition/error/ErrorDto.java
+++ b/src/main/java/com/kata/delivery/exposition/error/ErrorDto.java
@@ -1,0 +1,12 @@
+package com.kata.delivery.exposition.error;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class ErrorDto {
+    private String message;
+}

--- a/src/main/java/com/kata/delivery/exposition/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/kata/delivery/exposition/error/GlobalExceptionHandler.java
@@ -1,0 +1,18 @@
+package com.kata.delivery.exposition.error;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import reactor.core.publisher.Mono;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(Exception.class)
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
+    public Mono<ErrorDto> handleException(Exception ex) {
+        return Mono.just(new ErrorDto(ex.getMessage()));
+    }
+}

--- a/src/main/java/com/kata/delivery/infrastructure/repository/TimeslotRepositoryImpl.java
+++ b/src/main/java/com/kata/delivery/infrastructure/repository/TimeslotRepositoryImpl.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import org.springframework.stereotype.Repository;
 import lombok.RequiredArgsConstructor;
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 import com.kata.delivery.domain.DeliveryMode;
 import com.kata.delivery.domain.Timeslot;
 import com.kata.delivery.domain.TimeslotRepository;
@@ -18,6 +19,18 @@ public class TimeslotRepositoryImpl implements TimeslotRepository {
     @Override
     public Flux<Timeslot> findByModeAndDate(DeliveryMode mode, LocalDate date) {
         return springRepository.findByModeAndDate(mode, date)
+                .map(mapper::toVo);
+    }
+
+    @Override
+    public Mono<Timeslot> findById(Long id) {
+        return springRepository.findById(id)
+                .map(mapper::toVo);
+    }
+
+    @Override
+    public Mono<Timeslot> save(Timeslot timeslot) {
+        return springRepository.save(mapper.toEntity(timeslot))
                 .map(mapper::toVo);
     }
 }

--- a/src/test/java/com/kata/delivery/application/DeliveryServiceTest.java
+++ b/src/test/java/com/kata/delivery/application/DeliveryServiceTest.java
@@ -1,0 +1,64 @@
+package com.kata.delivery.application;
+
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import com.kata.delivery.application.DeliveryService;
+import com.kata.delivery.application.exception.TimeslotUnavailableException;
+import com.kata.delivery.application.mapper.DeliveryDtoMapper;
+import com.kata.delivery.application.mapper.TimeslotDtoMapper;
+import com.kata.delivery.domain.Delivery;
+import com.kata.delivery.domain.DeliveryRepository;
+import com.kata.delivery.domain.DeliveryMode;
+import com.kata.delivery.domain.Timeslot;
+import com.kata.delivery.domain.TimeslotRepository;
+import com.kata.delivery.exposition.dto.DeliveryRequest;
+
+import reactor.core.publisher.Mono;
+import reactor.test.StepVerifier;
+
+public class DeliveryServiceTest {
+
+    @Mock
+    private TimeslotRepository timeslotRepository;
+    @Mock
+    private DeliveryRepository deliveryRepository;
+
+    private DeliveryService service;
+
+    @BeforeEach
+    void setUp() {
+        MockitoAnnotations.openMocks(this);
+        service = new DeliveryService(timeslotRepository, deliveryRepository, new TimeslotDtoMapper(), new DeliveryDtoMapper());
+    }
+
+    @Test
+    void bookShouldFailWhenTimeslotMissing() {
+        DeliveryRequest request = new DeliveryRequest(1L, "client");
+        when(timeslotRepository.findById(1L)).thenReturn(Mono.empty());
+
+        StepVerifier.create(service.book(request))
+            .expectError(TimeslotUnavailableException.class)
+            .verify();
+    }
+
+    @Test
+    void bookShouldSucceedWhenTimeslotExists() {
+        DeliveryRequest request = new DeliveryRequest(1L, "client");
+        Timeslot slot = new Timeslot(1L, DeliveryMode.DELIVERY, LocalDate.now(), LocalTime.NOON, LocalTime.NOON.plusHours(1));
+        when(timeslotRepository.findById(1L)).thenReturn(Mono.just(slot));
+        Delivery delivery = new Delivery(null, 1L, "client");
+        when(deliveryRepository.save(delivery)).thenReturn(Mono.just(new Delivery(10L, 1L, "client")));
+
+        StepVerifier.create(service.book(request))
+            .expectNextMatches(d -> d.getId() == 10L)
+            .verifyComplete();
+    }
+}


### PR DESCRIPTION
## Summary
- add repository methods to save and find timeslots by id
- implement global exception handling with `ErrorDto`
- allow creating new timeslots via the API
- check timeslot availability when booking a delivery
- add unit tests for `DeliveryService`

## Testing
- `./mvnw -q test` *(fails: Could not resolve parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68599846d1e483299794c8d2226293ac