### PR TITLE
Implement Kafka event for delivery booking

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,10 +38,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-security</artifactId>
 		</dependency>
-		<dependency>
-			<groupId>org.springframework.boot</groupId>
-			<artifactId>spring-boot-starter-webflux</artifactId>
-		</dependency>
+                <dependency>
+                        <groupId>org.springframework.boot</groupId>
+                        <artifactId>spring-boot-starter-webflux</artifactId>
+                </dependency>
+                <dependency>
+                        <groupId>org.springframework.kafka</groupId>
+                        <artifactId>spring-kafka</artifactId>
+                </dependency>
 
 		<dependency>
 			<groupId>org.postgresql</groupId>

--- a/src/main/java/com/kata/delivery/domain/repositories/TimeslotCrudService.java
+++ b/src/main/java/com/kata/delivery/domain/repositories/TimeslotCrudService.java
@@ -14,4 +14,6 @@ public interface TimeslotCrudService {
     Mono<TimeslotVo> findById(Long id);
 
     Mono<TimeslotVo> save(TimeslotVo timeslotVo);
+
+    Mono<Void> deleteById(Long id);
 }

--- a/src/main/java/com/kata/delivery/infrastructure/kafka/DeliveryEvent.java
+++ b/src/main/java/com/kata/delivery/infrastructure/kafka/DeliveryEvent.java
@@ -1,0 +1,12 @@
+package com.kata.delivery.infrastructure.kafka;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class DeliveryEvent {
+    private Long timeslotId;
+}

--- a/src/main/java/com/kata/delivery/infrastructure/kafka/DeliveryEventConsumer.java
+++ b/src/main/java/com/kata/delivery/infrastructure/kafka/DeliveryEventConsumer.java
@@ -1,0 +1,18 @@
+package com.kata.delivery.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+import com.kata.delivery.domain.repositories.TimeslotCrudService;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryEventConsumer {
+
+    private final TimeslotCrudService timeslotCrudService;
+
+    @KafkaListener(topics = "${kafka.topic.delivery-booked}", groupId = "delivery-service")
+    public void handleDeliveryBooked(DeliveryEvent event) {
+        timeslotCrudService.deleteById(event.getTimeslotId()).subscribe();
+    }
+}

--- a/src/main/java/com/kata/delivery/infrastructure/kafka/DeliveryEventProducer.java
+++ b/src/main/java/com/kata/delivery/infrastructure/kafka/DeliveryEventProducer.java
@@ -1,0 +1,21 @@
+package com.kata.delivery.infrastructure.kafka;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class DeliveryEventProducer {
+
+    private final KafkaTemplate<String, DeliveryEvent> kafkaTemplate;
+
+    @Value("${kafka.topic.delivery-booked}")
+    private String topic;
+
+    public void sendDeliveryBooked(Long timeslotId) {
+        DeliveryEvent event = new DeliveryEvent(timeslotId);
+        kafkaTemplate.send(topic, event);
+    }
+}

--- a/src/main/java/com/kata/delivery/infrastructure/repository/impl/TimeslotCrudServiceImpl.java
+++ b/src/main/java/com/kata/delivery/infrastructure/repository/impl/TimeslotCrudServiceImpl.java
@@ -35,4 +35,9 @@ public class TimeslotCrudServiceImpl implements TimeslotCrudService {
         return springRepository.save(mapper.toEntity(timeslotVo))
                 .map(mapper::toVo);
     }
+
+    @Override
+    public Mono<Void> deleteById(Long id) {
+        return springRepository.deleteById(id);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,3 +3,14 @@ spring.application.name=delivery
 spring.r2dbc.url=r2dbc:postgresql://${POSTGRESQL_HOST:localhost}:${POSTGRESQL_PORT:5432}/vigihelp
 spring.r2dbc.username=${MYSQL_USER:postgres}
 spring.r2dbc.password=${MYSQL_PASSWORD:#adminadmin1}
+
+spring.kafka.bootstrap-servers=${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
+spring.kafka.consumer.group-id=delivery-service
+spring.kafka.consumer.auto-offset-reset=earliest
+spring.kafka.consumer.key-deserializer=org.apache.kafka.common.serialization.StringDeserializer
+spring.kafka.consumer.value-deserializer=org.springframework.kafka.support.serializer.JsonDeserializer
+spring.kafka.consumer.properties.spring.json.trusted.packages=*
+spring.kafka.producer.key-serializer=org.apache.kafka.common.serialization.StringSerializer
+spring.kafka.producer.value-serializer=org.springframework.kafka.support.serializer.JsonSerializer
+
+kafka.topic.delivery-booked=delivery-booked

--- a/src/test/java/com/kata/delivery/application/DeliveryVoServiceTest.java
+++ b/src/test/java/com/kata/delivery/application/DeliveryVoServiceTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import com.kata.delivery.infrastructure.kafka.DeliveryEventProducer;
 
 import com.kata.delivery.application.exception.TimeslotUnavailableException;
 import com.kata.delivery.application.mappers.DeliveryDtoMapper;
@@ -30,13 +31,15 @@ public class DeliveryVoServiceTest {
     private TimeslotCrudService timeslotCrudService;
     @Mock
     private DeliveryCrudService deliveryCrudService;
+    @Mock
+    private DeliveryEventProducer eventProducer;
 
     private DeliveryServiceImpl service;
 
     @BeforeEach
     void setUp() {
         MockitoAnnotations.openMocks(this);
-        service = new DeliveryServiceImpl(timeslotCrudService, deliveryCrudService, new TimeslotDtoMapper(), new DeliveryDtoMapper());
+        service = new DeliveryServiceImpl(timeslotCrudService, deliveryCrudService, new TimeslotDtoMapper(), new DeliveryDtoMapper(), eventProducer);
     }
 
     @Test


### PR DESCRIPTION
## Summary
- add spring-kafka dependency
- produce `DeliveryEvent` when a delivery is booked
- consume the event to delete the timeslot
- expose new timeslot `deleteById` in repository layer
- configure Kafka in `application.properties`
- update tests for new service constructor

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_6859ac2227ac832990d518e1f39333a8